### PR TITLE
fix: argument cant contains space

### DIFF
--- a/bin/sudo
+++ b/bin/sudo
@@ -1,5 +1,14 @@
 #!/usr/bin/env node
 
+var args = [];
+for(var i in process.argv.slice(2)){
+	v=process.argv.slice(2)[i];
+	if (v.indexOf(' ')!=-1) {
+		v='"'+v+'"';
+	}
+	args.push(v);
+}
+
 require('../lib/windosu').exec(
-	process.argv.slice(2).join(' ')
+	args.join(' ')
 )


### PR DESCRIPTION
e.g
sudo mklink /J "My Documents" D:\Users\Larvata\Documents
==>
C:\Windows\system32\cmd.exe  /S /D /c" 2>&1 ( mklink /J My Documents D:\Users\Larvata\Documents )"

quotation marks on "My Docuemnts" is missing
