### PR TITLE
Fix cmd popping up for a blink when elevating a process

### DIFF
--- a/windosu-elevate.cmd
+++ b/windosu-elevate.cmd
@@ -30,7 +30,7 @@ If ERRORLEVEL 1 (
 
 :: Create a temporary VBScript
    Echo Set objShell = CreateObject^("Shell.Application"^) > %_tempvbs%
-   Echo objShell.ShellExecute "%~f0", "", "", "runas", 1 >> %_tempvbs%
+   Echo objShell.ShellExecute "%~f0", "", "", "runas", 0 >> %_tempvbs%
 
 :: Relaunch this script 'As Admin'
    cscript "%_tempvbs%" //nologo


### PR DESCRIPTION
By looking at `ShellExecute` documentation:

https://msdn.microsoft.com/en-us/library/windows/desktop/gg537745(v=vs.85).aspx

I see that the fifth argument corresponds to `vShow`:

> A recommendation as to how the application window should be displayed initially.

The current value, 1, corresponds to:

> Open the application with a normal window. If the window is minimized
> or maximized, the system restores it to its original size and
> position.

A better value seems to be 0:

> Open the application with a hidden window.

This change effectively hides the cmd window and gives a more polished
experience.