### PR TITLE
Inline invisible.vbs script

### DIFF
--- a/invisible.vbs
+++ b/invisible.vbs
@@ -1,1 +1,0 @@
-CreateObject("Wscript.Shell").Run "" & WScript.Arguments(0) & "", 0, False

--- a/lib/windosu.js
+++ b/lib/windosu.js
@@ -19,7 +19,6 @@ module.exports.exec = function (command, options, callback) {
                         pipe: '"' + process.execPath + '" "' + path.join(__dirname, 'pipe.js') + '"',
                         input: inputName = id + '-in',
                         output: outputName = id + '-out',
-                        invisible: path.join(__dirname, '..', 'invisible.vbs'),
                         stderr_redir: process.stdout.isTTY ? '2>&1' : '2> %ERROR%'
                     };
                 for (var n in temps)

--- a/src/windosu.latte
+++ b/src/windosu.latte
@@ -32,7 +32,6 @@ module.exports.exec = function (command, options, callback) {
 			pipe: "\""+process.execPath+"\" \"" + path.join(__dirname, "pipe.js") + '"',
 			input: inputName = id + '-in',
 			output: outputName = id + '-out',
-			invisible: path.join(__dirname, '..', 'invisible.vbs'),
 
 			stderr_redir: ( process.stdout.isTTY
 				// If outputting to console, redirect stderr

--- a/windosu-elevate.cmd
+++ b/windosu-elevate.cmd
@@ -6,6 +6,7 @@
 Set _temp={{ temp }}
 Set _tempfile=%_temp%SaveDrives.txt
 Set _tempvbs=%_temp%getadmin.vbs
+Set _tempinvisible=%_temp%invisible.vbs
 Set DIR={{ dir }}
 Set INPUT={{ input }}
 Set OUTPUT={{ output }}
@@ -49,7 +50,9 @@ If ERRORLEVEL 1 (
 
 :: Hide the window
 IF [%1]==[] (
-   wscript.exe "{{ invisible }}" "cmd /C %~f0 run"
+   Echo CreateObject^("Wscript.Shell"^).Run "" ^& WScript.Arguments^(0^) ^& "", 0, False > %_tempinvisible%
+   wscript.exe %_tempinvisible% "cmd /C %~f0 run"
+   Del %_tempinvisible%
 ) else (
 
    If exist "%_tempvbs%" ( Del "%_tempvbs%" )

--- a/windosu-runas.cmd
+++ b/windosu-runas.cmd
@@ -8,10 +8,14 @@ Set INPUT={{ input }}
 Set OUTPUT={{ output }}
 Set CLI_WIDTH={{ cliWidth }}
 Set PIPE={{ pipe }}
+Set _temp={{ temp }}
+Set _tempinvisible=%_temp%invisible.vbs
 
 :: Hide the window
 IF [%1]==[] (
-   wscript.exe {{ invisible }} "cmd /C %~f0 run"
+   Echo CreateObject^("Wscript.Shell"^).Run "" ^& WScript.Arguments^(0^) ^& "", 0, False > %_tempinvisible%
+   wscript.exe %_tempinvisible% "cmd /C %~f0 run"
+   Del %_tempinvisible%
 ) else (
    
    cd /D %DIR%


### PR DESCRIPTION
Currently, `windosu-elevate.cmd` and `windosu-runas.cmd` call a separate
file named `invisible.vbs` to perform their tasks.

This approach doesn't work when running Windosu in Electron as an `asar`
package. `asar` archives are mounted as virtual directories in Electron.

More information about `asar` archives here:

https://github.com/atom/electron/blob/master/docs/tutorial/application-packaging.md

Given that the files don't really exist in the filesystem, the call to
`invisible.vbs` fails. Electron copes with this limitation by patching
certain node fs functions like `child_process.execFile` to extract the
file before executing it, but this of course is not possible from a cmd
file.

A decent workaround, given that `invisible.vbs` is a one line script, is
to inline it in the scripts is being called.

Fixes: https://github.com/resin-io/herostratus/issues/20