### PR TITLE
Make use of `rimraf` to cleanup temporal dependencies

### DIFF
--- a/lib/windosu.js
+++ b/lib/windosu.js
@@ -1,7 +1,7 @@
 function __when(v, n) {
     return v && typeof v.then === 'function' ? v.then(n) : n(v);
 }
-var child_process = require('child_process'), Q = require('q'), fs = require('fs'), path = require('path'), Tail = require('tail').Tail, cliWidth = require('cli-width'), pipe = require('./pipe');
+var child_process = require('child_process'), Q = require('q'), fs = require('fs'), path = require('path'), Tail = require('tail').Tail, cliWidth = require('cli-width'), rimraf = require('rimraf'), pipe = require('./pipe');
 module.exports.exec = function (command, options, callback) {
     options = options || {};
     var promise = function () {
@@ -68,7 +68,8 @@ module.exports.exec = function (command, options, callback) {
                             if (tail)
                                 tail.unwatch();
                             for (var n in temps) {
-                                fs.unlink(temps[n]);
+                                rimraf(temps[n], function () {
+                                });
                             }
                             return inputPromise.then(function (input) {
                                 return input.closeAndWait();

--- a/package.json
+++ b/package.json
@@ -23,10 +23,11 @@
     "url": "https://github.com/tehsenaus/windosu/issues"
   },
   "dependencies": {
-    "temp": "~0.6.0",
     "cli-width": "^1.1.0",
     "q": "~0.9.7",
-    "tail": "~0.3.1"
+    "rimraf": "^2.5.2",
+    "tail": "~0.3.1",
+    "temp": "~0.6.0"
   },
   "devDependencies": {
     "grunt": "~0.4.1",

--- a/src/windosu.latte
+++ b/src/windosu.latte
@@ -5,6 +5,7 @@ var child_process = require('child_process'),
 	path = require('path'),
 	Tail = require('tail').Tail,
 	cliWidth = require('cli-width'),
+	rimraf = require('rimraf'),
 	pipe = require('./pipe');
 
 
@@ -88,7 +89,7 @@ module.exports.exec = function (command, options, callback) {
 
 			// Clean temps (async)
 			for ( var n in temps ) {
-				fs.unlink(temps[n]);
+				rimraf(temps[n], function () {});
 			}
 
 			// Wait for input to be closed first, so stdin is


### PR DESCRIPTION
I've encountered some `EBUSY` errors when running this module on
Electron applications, which `rimraf` gracefully handles by retrying
automatically + other goodies.

I needed to pass a blank callback function explicitly, since otherwise
`rimraf` complained that there was no callback.

Signed-off-by: Juan Cruz Viotti jviottidc@gmail.com
